### PR TITLE
Braveheart improvements

### DIFF
--- a/scottishVillage/scottishVillage.css
+++ b/scottishVillage/scottishVillage.css
@@ -398,6 +398,7 @@ div[class*="braveheart-lower-arm-"] {
 .braveheart-lower-arm-right {
   top: 35px;
   left:320px;
+  animation: rotate-blade 2s linear infinite;
 }
 
 .braveheart-lower-arm-left {
@@ -442,12 +443,20 @@ div[class*="braveheart-sword-"] {
   position: relative;
 }
 
+@keyframes rotate-blade {
+  0% { transform: rotate(0deg); }
+  50% { transform: rotate(20deg); }
+  100% { transform: rotate(0deg); }
+}
+
 .braveheart-sword {
   position: absolute;
   top: -190px;
   left: 270px;
   height: 230px;
   width: 100px;
+  transform-origin: bottom;
+  animation: rotate-blade 2s linear infinite;
 }
 
 .braveheart-sword-handle {

--- a/scottishVillage/scottishVillage.css
+++ b/scottishVillage/scottishVillage.css
@@ -483,4 +483,13 @@ div[class*="braveheart-sword-"] {
 .braveheart-speech {
   left: var(--braveheart-speech-left);
   top: 100px;
+  animation: braveheart-speech-flicker 2s infinite ease-out;
+}
+
+@keyframes braveheart-speech-flicker { 
+  0% {opacity: 0} 
+  25% {opacity: 0}
+  50% {opacity: 1} 
+  75% {opacity: 0}
+  100% {opacity: 0}  
 }


### PR DESCRIPTION
Add animation to make the speech bubble fade in and out with opacity. Use transform to make the sword and right arm rotate. Both animations are infinite.